### PR TITLE
12-buildroot-with-gcc - Test Buildroot using gcc-arm as a base

### DIFF
--- a/buildroot/Dockerfile
+++ b/buildroot/Dockerfile
@@ -1,17 +1,13 @@
-# TODO: Can't get buildroot to use the pre-installed toolchain - would save a lot of time in the build
-#FROM robotpajamas/gcc-arm-linux-gnueabihf:10.3-2021.07 as builder
-
-# TODO: Cannot inherit from gcc-arm-linux-gnueabihf because there is a buildroot + gcc10 problem
-# Need to use Buster with gcc8 or gcc9
-FROM debian:buster-20210902-slim
+FROM robotpajamas/gcc-arm-linux-gnueabihf:10.3-2021.07 as builder
 
 LABEL maintainer="suresh@robotpajamas.com"
 
-ARG BUILDROOT_VERSION=buildroot-2021.11
+ARG BUILDROOT_VERSION=buildroot-2021.11.1
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG DEBIAN_FRONTEND=non-interactive
 
+USER root
 RUN apt-get update \
     && apt-get install -y -qq --no-install-recommends \
     bash \
@@ -38,9 +34,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && wget -O- https://buildroot.org/downloads/${BUILDROOT_VERSION}.tar.gz | tar -xvz \
     && mv /${BUILDROOT_VERSION} /buildroot \
-    && mkdir /app /app/cache /app/src /app/output \
-    && groupadd -r armoire \
-    && useradd --no-log-init -u 1000 -r -g armoire armothy \
+    && mkdir -p /app /app/cache /app/src /app/output \
     && chown -R armothy:armoire /app /buildroot
 
 USER armothy
@@ -48,6 +42,7 @@ USER armothy
 ENV ARCH="arm"
 ENV BR2_CCACHE_DIR="/app/cache/ccache"
 ENV BR2_DL_DIR="/app/cache/dl"
+ENV CCACHE_DIR="/app/cache/ccache"
 
 WORKDIR /app/output
 

--- a/buildroot/README.md
+++ b/buildroot/README.md
@@ -4,11 +4,11 @@
 
 When using these dev envs, I tend to just jump into bash directly and use the container like it's a VM, as I find it easier. 
 
-`docker -v $(pwd):/app -it robotpajamas/buildroot:2021.02.5 bash`
+`docker -v $(pwd):/app -it robotpajamas/buildroot:2021.11.1 bash`
 
 However, they can also be used externally (e.g. when calling from a script as part of automation)
 
-`docker -v $(pwd):/app -it robotpajamas/buildroot:2021.02.5 make O=/app/output -C /buildroot beaglebone_defconfig && make`
+`docker -v $(pwd):/app -it robotpajamas/buildroot:2021.11.1 make O=/app/output -C /buildroot beaglebone_defconfig && make`
 
 There may be some permissions issues here, if the volume doesn't match what is expected.
 
@@ -18,9 +18,19 @@ There may be some permissions issues here, if the volume doesn't match what is e
 ARCH="arm"
 BR2_CCACHE_DIR="/app/cache/ccache"
 BR2_DL_DIR="/app/cache/dl"
+CCACHE_DIR="/app/cache/ccache"
 ```
+
+## Defconfig variables
+
+In order to use the built-in toolchain, ensure the following is in your defconfig:
+
+```bash
+BR2_TOOLCHAIN_EXTERNAL=y
+BR2_TOOLCHAIN_EXTERNAL_PREINSTALLED=y
+BR2_TOOLCHAIN_EXTERNAL_PATH="/gcc-arm"
+```
+
 ## TODOs
 
-- Can't get buildroot to use the pre-installed toolchain - otherwise could use robotpajamas/gcc-arm-linux-gnueabihf:10.3-2021.07
-- Buildroot has a gcc10 problem, so need to use gcc8 or gcc9 (hence using Buster instead of Bullseye)
 - Setup a BR2_EXTERNAL_TREE example


### PR DESCRIPTION
Closes #12 