### PR TITLE
26-curses - Fix u-boot-builder and linux-kernel-builder missing curses lib

### DIFF
--- a/linux-kernel-builder/Dockerfile
+++ b/linux-kernel-builder/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     build-essential \
     flex \
     git \
+    libncurses5-dev \
     libssl-dev \
     make \
     && rm -rf /var/lib/apt/lists/* \

--- a/linux-kernel-builder/Dockerfile
+++ b/linux-kernel-builder/Dockerfile
@@ -2,7 +2,7 @@ FROM robotpajamas/gcc-arm-linux-gnueabihf:10.3-2021.07 as builder
 
 LABEL maintainer="suresh@robotpajamas.com"
 
-ARG LINUX_TAG=v5.4.106
+ARG LINUX_TAG=v5.17.4
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG DEBIAN_FRONTEND=non-interactive

--- a/u-boot-builder/Dockerfile
+++ b/u-boot-builder/Dockerfile
@@ -11,11 +11,13 @@ USER root
 RUN apt-get update \
     && apt-get install -y -qq --no-install-recommends \
     bash \
+    bc \
     bison \
     build-essential \
     ca-certificates \
     flex \
     git \
+    libncurses5-dev \
     libssl-dev \
     make \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Closes #26 